### PR TITLE
Add newline to end of output.

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -30,7 +30,7 @@ if (!function_exists('dd')) {
         array_map(function ($x) {
             $string = (new Dump(null, true))->variable($x);
 
-            echo (PHP_SAPI == 'cli' ? strip_tags($string) : $string);
+            echo (PHP_SAPI == 'cli' ? strip_tags($string) . PHP_EOL : $string);
         }, func_get_args());
 
         die(1);


### PR DESCRIPTION
Adding a newline at the end of the output makes for much easier reading when dumping to the console.